### PR TITLE
add pull request finder script

### DIFF
--- a/scripts/find-prs-for-release.sh
+++ b/scripts/find-prs-for-release.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+set -euo pipefail
+
+# Find all PRs in subsurface/subsurface that first appear in a given CICD release
+# by walking the commit range between two releases.
+#
+# Usage: find-prs-for-release.sh --tag <vX.Y.N-CICD-release> [--from-tag <vX.Y.M-CICD-release>]
+#
+
+# Helper functions
+croak() {
+	echo "$0: $*" >&2
+	exit 1
+}
+
+croak_usage() {
+	croak "Usage: $0 --tag <tag> [--from-tag <tag>]"
+}
+
+# Parse arguments
+TAG=""
+FROM_TAG=""
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--tag)
+			[[ -n $TAG ]] && croak_usage
+			TAG="$2"
+			shift 2
+			;;
+		--from-tag)
+			[[ -n $FROM_TAG ]] && croak_usage
+			FROM_TAG="$2"
+			shift 2
+			;;
+		*)
+			croak_usage
+			;;
+	esac
+done
+
+[[ -z $TAG ]] && croak_usage
+
+# Locate nightly-builds checkout
+SCRIPT_SOURCE=$(dirname "${BASH_SOURCE[0]}")
+SUBSURFACE_ROOT=$(cd "$SCRIPT_SOURCE/.." && pwd)
+
+NB_DIR=""
+if [[ -d "$SUBSURFACE_ROOT/../nightly-builds" ]]; then
+	NB_DIR="$SUBSURFACE_ROOT/../nightly-builds"
+else
+	NB_DIR="$SUBSURFACE_ROOT/nightly-builds"
+	[[ -d "$NB_DIR" ]] || \
+		git clone https://github.com/subsurface/nightly-builds "$NB_DIR" &> /dev/null || croak "Failed to clone nightly-builds"
+fi
+
+# Fetch latest refs
+git -C "$NB_DIR" fetch --all -q || croak "Failed to fetch nightly-builds refs"
+
+# Helper: extract build number from tag for validation
+extract_buildnr() {
+	[[ $1 =~ ^v[0-9]+\.[0-9]+\.([0-9]+)-CICD-release$ ]] && echo "${BASH_REMATCH[1]}"
+}
+
+# Helper: find SHA for a given build number by checking branch-for-* refs
+find_sha_for_buildnr() {
+	local target_buildnr="$1"
+
+	# Enumerate all branch-for-* refs
+	while IFS= read -r ref_name; do
+		# Extract SHA from branch name: branch-for-<sha>
+		# The ref_name could be refs/remotes/origin/branch-for-<sha> or refs/heads/branch-for-<sha>
+		# We want to extract just the <sha> part
+		sha=$(echo "$ref_name" | sed -E 's/^.*branch-for-([a-f0-9]+)$/\1/')
+
+		# Skip if extraction failed (malformed ref like plain "branch-for-")
+		[[ -z "$sha" || "$sha" == "$ref_name" ]] && continue
+
+		# Check if this ref has the target build number
+		if git -C "$NB_DIR" show "$ref_name:latest-subsurface-buildnumber" 2>/dev/null | grep -qx "$target_buildnr"; then
+			echo "$sha"
+			return 0
+		fi
+	done < <(git -C "$NB_DIR" for-each-ref --format='%(refname)' 'refs/remotes/origin/branch-for-*' 'refs/heads/branch-for-*' 2>/dev/null)
+
+	return 1
+}
+
+# Validate tag format first
+if [[ ! $TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+-CICD-release$ ]]; then
+	croak "Invalid tag format: $TAG. Expected format: vX.Y.N-CICD-release (e.g. v6.0.5629-CICD-release)"
+fi
+
+# Extract build number from tag
+TAG_BUILDNR=$(extract_buildnr "$TAG")
+[[ -z $TAG_BUILDNR ]] && croak "Cannot parse build number from tag: $TAG"
+
+# Find SHA for this release
+TO_SHA=$(find_sha_for_buildnr "$TAG_BUILDNR")
+RESOLVED_BUILDNR="$TAG_BUILDNR"
+
+# If exact match not found, try the next build (in case tags are pointing to earlier commits)
+if [[ -z $TO_SHA ]]; then
+	FALLBACK_BUILDNR=$((TAG_BUILDNR + 1))
+	TO_SHA=$(find_sha_for_buildnr "$FALLBACK_BUILDNR")
+	if [[ -n $TO_SHA ]]; then
+		RESOLVED_BUILDNR="$FALLBACK_BUILDNR"
+	fi
+fi
+
+[[ -z $TO_SHA ]] && croak "Cannot find subsurface commit for release $TAG (build $TAG_BUILDNR or $((TAG_BUILDNR + 1)))"
+
+# Handle FROM_TAG
+if [[ -n $FROM_TAG ]]; then
+	if [[ ! $FROM_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+-CICD-release$ ]]; then
+		croak "Invalid from-tag format: $FROM_TAG. Expected format: vX.Y.N-CICD-release"
+	fi
+
+	FROM_BUILDNR=$(extract_buildnr "$FROM_TAG")
+	[[ -z $FROM_BUILDNR ]] && croak "Cannot parse build number from from-tag: $FROM_TAG"
+
+	FROM_SHA=$(find_sha_for_buildnr "$FROM_BUILDNR")
+
+	# Fallback: try adjacent build number
+	if [[ -z $FROM_SHA ]]; then
+		FROM_SHA=$(find_sha_for_buildnr "$((FROM_BUILDNR + 1))")
+	fi
+
+	[[ -z $FROM_SHA ]] && croak "Cannot find subsurface commit for from-tag $FROM_TAG (build $FROM_BUILDNR)"
+else
+	# Find the previous release automatically based on the resolved build number
+	PREV_BUILDNR=$((RESOLVED_BUILDNR - 1))
+	FROM_SHA=$(find_sha_for_buildnr "$PREV_BUILDNR")
+
+	if [[ -z $FROM_SHA ]]; then
+		# No previous release found; use the repository root commit
+		# This can happen for the very first release
+		echo "No previous release found; listing commits from root to $TO_SHA" >&2
+		FROM_SHA=$(git -C "$NB_DIR" rev-list --max-parents=0 HEAD 2>/dev/null | head -n1)
+		[[ -z $FROM_SHA ]] && croak "Cannot determine repository root commit"
+	fi
+fi
+
+# Enumerate commits in range and find PRs
+mapfile -t SHAS < <(gh api "repos/subsurface/subsurface/compare/${FROM_SHA}...${TO_SHA}" --paginate --jq '.commits[].sha' 2>/dev/null)
+
+if [[ ${#SHAS[@]} -eq 0 ]]; then
+	# No commits in range, or API call failed; exit silently
+	exit 0
+fi
+
+# For each commit, find associated PRs
+declare -a PR_NUMS
+for sha in "${SHAS[@]}"; do
+	while IFS= read -r pr_num; do
+		[[ -n $pr_num ]] && PR_NUMS+=("$pr_num")
+	done < <(gh api "repos/subsurface/subsurface/commits/${sha}/pulls" --jq '.[].number' 2>/dev/null)
+done
+
+# Deduplicate and output (numeric sort, skip if empty)
+if [[ ${#PR_NUMS[@]} -gt 0 ]]; then
+	printf '%s\n' "${PR_NUMS[@]}" | sort -n -u
+fi


### PR DESCRIPTION
- **theme: escape dive data in HTML export to fix rendering bugs**
- **core: use HTTPS for Geonames API endpoints**
- **Desktop: Fix Segfault when Importing Dives into Trips.**
- **Import: Add the Unit Dive Number for APD Inspiration UDDF Imports.**
- **Fix the Test Data for the APD Inspiration Import Tests.**
- **Update libdivecomputer to latest on 'Subsurface-DS9'.**
- **Desktop: Add 'any dive computer' Filter Constraint.**
- **Statistics: Add 'Dive computer' Stats Variable.**
- **Desktop: Fix the Cylinder List Pressures when Modifying Sensor Assignments.**
- **Fix the problems with tank sensors when merging dives.**
- **Fix incorrect uses of 'NO_SENSOR'.**
- **Improve the tests for tank sensor merging.**
- **Fix the import of pressure information through libdivecomputer.**
- **Add 'No Sensor Mapping' Sentinel to the In-memory Representation.**
- **Ubuntu Plucky End of Live**
- **Fix Evaluation of the Release Version that a Changeset is in.**
- **Add seconds to duration label on dive notes tab**
- **Import: Recognise the Heinrichs Weikamp OSTC 4/5 Models Correctly.**
- **Update the list of supported dive computers.**
- **Documentation: Fix the Version Generation (again).**
- **Documentation: Fix Build Problems with the Manuals.**
- **Documentation: Release Documentation Artifact**
- **Pack the documentation for the release.**
- **Pack the documentation for the release.**
- **core: fix integer sign in localized sprintf functions**
- **cleanup: remove unused define of PATH_MAX**
- **cleanup: move print_qt_version() into subsurfacestartup.cpp**
- **cleanup: move (un)lock_planner() to profile.cpp**
- **Fix missing offset for dive computer timestamp when storing to git.**
- **cleanup: move a number of functions from qthelper.cpp to string-format.cpp**
- **cleanup: remove "gettextfromc.h" include from qthelper.h**
- **cleanup: use QStringLiteral() for string literals in string-format.cpp**
- **cleanup: move distance_string() to string-format.cpp**
- **cleanup: move printGPSCoords to string-format.cpp**
- **cleanup: move decoMode() to pref.cpp**
- **cleanup: remove changesCallback**
- **cleanup: move get_cylinder_map_* to equipment.cpp**
- **cleanup: remove unnecessary include in equipment.h**
- **cleanup: remove stale function declaration in qthelper.h**
- **cleanup: move render_seconds_to_string() to string-format.cpp**
- **Update libdivecomputer to latest on 'Subsurface-DS9'.**
- **cleanup: use std::string's sorting function in divepicturemodel.cpp**
- **cleanup: remove unnecessary 'this' capture from lambdas**
- **Fail the macOS Build if the .dmg Can't Be Built.**
- **mobile: invalidate both models in MobileModels**
- **Fix Firmware Version Detection for Garmin Dive Computers.**
- **Use the define for the firmware version provided by libdivecomputer.**
- **Add a Constant for the Serial Number Key.**
- **Update libdivecomputer to the latest on 'Subsurface-DS9'.**
- **desktop: Rename Tab "Extra Info" to "Dive Computer Info"**
- **desktop: remove "windowTitle" property from tab widgets**
- **desktop: show information on divecomputer tab**
- **divecomputer: filter out "Serial" and "FW Version" from extra_data**
- **Trim libdivecomputer Provided Values.**
- **build: remove cmake include**
- **build: remove unnecessary include_directiories() directive**
- **Qt 6: add generic yml to build Debian based Linux**
- **Fetch from git before changing branch for googlemaps.**
- **Fix Pathing Issue and Inconsistencies in Build Scripts.**
- **Update libdivecomputer to the latest on 'Subsurface-DS9'.**
- **CICD: Fix the Fedora Build.**
- **Update the .gitignore file.**
- **Turn off printing and usermanual support in Ubuntu >= 25.10**
- **Disable lto optimization in ubuntu packaging**
- **Open user manual in external browser if compiled with NO_USERMANUAL**
- **Update libdivecomputer to the latest on 'Subsurface-DS9'.**
- **Windows/MSVC: first attempt to create Windows build with MSVC**
- **Windows/MSVC: start documentation for local builds on Windows**
- **Windows/MSVC: don't use pkg-config or find_package**
- **Windows/MSVC: create libdc version.h/revision.h directly**
- **Windows/MSVC: don't ever use the msvc bundled vcpkg**
- **Windows/MSVC: use cmake -E to execute commands**
- **Windows/MSVC: fix incorrect libdivecomputer reference**
- **Windows/MSVC: deal with gcc/clang specific compiler flags**
- **Windows/MSVC: compile against C++20**
- **Windows/MSVC: we cannot use ?: in files compiled by msvc**
- **Windows/MSVC: use PowerShell for helper scripts**
- **Windows/MSVC: use static member functions instead of lambdas**
- **Windows/MSVC: our clever preprocessor use is too much for MSVC**
- **cleanup: remove unused #includes**
- **Windows/MSVC: add missing type definitions**
- **Windows/MSVC: replace GNU case range extension**
- **Windows/MSVC: avoid symlinks**
- **Windows/MSVC: avoid mixing designated and non-designated initializers**
- **Windows/MSVC: get correct definitions for file functions**
- **Windows/MSVC: reorder header to avoid conflicts**
- **Windows/MSVC: str(n)casecmp aren't available with MSVC**
- **Windows/MSVC: C99 designated array initializers aren't supported in C++**
- **Windows/MSVC: simplify MATCH macro**
- **Windows/MSVC: use C++17 standard annotations**
- **Windows/MSVC: avoid C99 compound literal pattern**
- **cleanup: we haven't supported Windows Vista in a long time**
- **Windows/MSVC: make code more ugly for initializers**
- **Windows/MSVC: dirent replacement**
- **Windows/MSVC: avoid conflicting min/max definitions**
- **Windows/MSVC: timezone isn't available**
- **Windows/MSVC: std::strview isn't guaranteed to return char* for begin()**
- **Windows/MSVC: replace __attribute for MSVC**
- **Windows/MSVC: make get-gersion.ps1 more robust**
- **Windows/MSVC: turn off Qt version tagging**
- **Windows/MSVC: use ANSI functions for char strings**
- **Windows/MSVC: use wide strings where required**
- **Windows/MSVC: fix type confusion**
- **Windows/MSVC: explicit template instantiations for MSVC**
- **Windows/MSVC: update install for Qt 6**
- **Windows/MSVC: run windeployqt at install time**
- **Windows/MSVC: more get-version.ps1 fixes**
- **Windows/MSVC: update README**
- **Windows/MSVC: update the GitHub Action**
- **Windows/MSVC: another attempt to get the correct Qt6 path**
- **Windows/MSVC: add qlitehtml to the build**
- **Windows/MSVC: include user manual for GitHub builds**
- **Mobile: remove references to deleted files**
- **non-MSVC: fix overeager changes by Claude**
- **Add artifact links to pull request for Windows MSVC builds.**
- **GitHub Action: remove concurrency**
- **GitHub Action: use more reasonable key for cache**
- **cleanup: replace the strange Claude induced switch statements**
- **Windows: use NSIS install action**
- **GitHub Action: don't build on push to the branch**
- **GitHub: use shared versioning from Windows-MSVC workflow**
- **CICD: Fix the Windows MSVC build.**
- **AI/LLMs: set up some instructions for Claude and Copilot**
- **AI/LLMs: Claude is an idiot and so am I**
- **Silence compiler warnings about unused linker parameters**
- **Let the user decide about the size of exported profile**
- **Update user manual with new profile export features.**
- **macOS: Fix the Homebrew Based Build.**
- **Bump actions/upload-artifact from 6 to 7**
- **Bump actions/cache from 4 to 5**
- **Bump actions/checkout from 4 to 6**
- **Desktop: Use the Packaged HTML User Manual when Opening the Manual in the Browser.**
- ** Set the 'claude-review.yml' workflow to manual / comment-mention only until we can get it sorted.**
- **CICD: Add a Workflow to Publish the CICD Release.**
- **Fix data format bug in the 'notify-release-coordinator' workflow.**
- **Fix: Filter out orphaned workflows with empty paths in publish-release**
- **CICD: Fix the 'publish-release' workflow.**
- **CICD: Fix the 'publish-release' workflow.**
- **CICD: Add debug statement to the 'publish-release' workflow.**
- **Fix dive-site selection/create handling**
- **cleanup: avoid crash initializing std::string from NULL**
- **Fix bug in subsurface XML to DivelogsDE XML export parsing.**
- **DC support: at BLE detection for Mares Quad Ci**
- **Cleanup: make BT/BLE logs less noisy**
- **Importer: Add the Heinrichs Weikamp OSTC Nano.**
- **Update the list of supported dive computers.**
- **Import: Add support for the Shearwater Swift GPS**
- **Add Support for Importing the Location from DC_FIELD_LOCATION.**
- **Fix Tests to Include Location Information.**
- **Tests: Add Tests for Printing.**
- **Bump microsoft/setup-msbuild from 2 to 3**
- **Add the Seac BLE service**
- **Support reading BLE characteristic without notify**
- **Empty commit to trigger a CICD release.**
- **build: increase C++ version to C++20**
- **Increase kirigami version to 6.9.23**
- **mobile: make mobile app run**
- **simplify CMakeLists by removing Qt5 support for mobile**
- **make sure cmake finds ECM**
- **mobile on desktop: run macdeployqt**
- **remove platform specific target_link_directories**
- **make sure that we find the Kirigami QML modules**
- **Kirigami: add compatibility patch**
- **switch mobile on desktop test builds to Qt 6**
- **CICD/mobile/Q6: add missing packages**
- **Android: first steps towards Qt 6 build**
- **Android/Qt6: mechanical attempt of Qt 6 port**
- **Android: switch to using preinstalled SDK/NDK**
- **GitHub/Fedora: explicitly install 'which'**
- **mobile: don't build Kirigami against DBUS**
- **GitHub/Android: slow progress with the Android action**
- **GitHub/Android: add caching**
- **GitHub/Android: more build fixes**
- **Android: crazy hack of androiddeployqt to avoid AGP incompatibility**
- **Android: forgot to update the Java code**
- **Android: minSdkVersion is now 28**
- **Android: another compatibility issue in build.gradle**
- **Android: correct the path for QtActivity**
- **Android: bundle OpenMP**
- **Mobile: provide a qmldir for our QML module**
- **mobile: resurrect a few Kirigami patches**
- **GitHub: add Ubuntu arm64 runner for Qt 6**
- **Cleanup: don't write out negative CNS values**
- **GitHub: siplify the various Ubuntu and Debian builds**
- **Mobile: build Kirigami as shared library**
- **Mobile: fix layout issue in StatisticsPage**
- **Mobile: deal with the changes to action button**
- **Mobile: fix layout for filter input**
- **Mobile: get the buttons and menus to be accessible**
- **Mobile: fix vertical alignment in menubar**
- **Mobile: stop pinning to old Kirigami version**
- **Mobile: remove all versioning from components**
- **Mobile: convert actions button to ActionToolBar**
- **Mobile: avoid double pop when canceling / exiting**
- **Mobile: fix signal handlers**
- **Mobile: remove Back entries in menues**
- **Mobile: work around binding loops**
- **Mobile: fix toggle switch behavior**
- **Mobile: fix incorrect theme color reference**
- **Mobile: need to access different element in Qt 6**
- **Mobile: Units.gridUnit is no longer writeable**
- **cleanup: don't set AA_EnableHighDpiScaling for Qt 6**
- **Mobile: update to Qt 6 signal handler syntax**
- **Mobile: do our own buttons**
- **Android: use ninja to speed up builds**
- **Android: switch to OpenSSL 3.4.4**
- **Android: add Bluetooth permissions the Qt 6 way**
- **Mobile: fix scrolling issue in dropdown**
- **Android: w/ Qt 6 we need to save DeviceInfo**
- **Android: build signed AAB for Google Play Store**
- **Android: use BUILDNR for Google Play versionCode**
- **Android: update android-build container**
- **Android: use new container for GitHub action**
- **Android: fix Intent creation**
- **Android: fix checking the wrong property**
- **Android: don't use static JNI environment**
- **Mobile: remove unused code**
- **Mobile: implement the missing gradient**
- **Android: don't hardcode arch**
- **Android: remove duplicate declaration**
- **Cleanup: remove commented out code**
- **Cleanup: sync action version**
- **iOS: first stab of iOS build**
- **iOS: global static QObjects cause crashes on iOS**
- **Mobile: set colors for our icons and drawer backgrounds**
- **iOS: correctly bundle the icons**
- **iOS: fix version string generation**
- **iOS: don't claim to have a storyboard**
- **iOS: tell Xcode to create the missing DWARF file**
- **Mobile: add Kirigami patch for icon styling**
- **iOS: add submodule checkout to build script**
- **iOS: set up new GitHub workflow**
- **iOS: work around cmake minimum**
- **Android: prepare for 16k pages size requirement**
- **Android: explicitly sign the .AAB**
- **iOS: add Qt binaries to the host path / cmake search path**
- **Mobile: attempt to re-enable swiping between dives**
- **iOS: add missing Qt modules and tools**
- **iOS: add script to enable signing builds**
- **Mobile: a different approach to swiping between dives**
- **Mobile: fix theme colors**
- **Android: fix crash for API 34 and newer**
- **Android: fix crash with older Android versions**
- **Android: don't draw behind the OS UI elements**
- **Android: boost initial font size for some devices**
- **Mobile: attempt to better size text fields**
- **iOS: update the version in the plist after build**
- **Mobile: make sure globalDrawer menu works from everywhere**
- **Mobile: move Kirigami build and install dirs out of the source tree**
- **cleanup: move libdivecomputer build out of src tree**
- **cleanup: remove unused files and update READMEs**
- **Android: allow building signed APK/AAB locally**
- **Mobile: always recreate ECM**
- **Mobile: ensure consistent checkout of Kirigami**
- **Mobile: there's no point to having to custom TextFields**
- **Mobile: fix DivePlannerEdit layout**
- **Mobile: fix the planner drop downs**
- **Mobile: fix cylinder dropdown behavior**
- **Mobile: more tuning of elements**
- **Mobile: move row headers inside ListView**
- **iOS: fix post-build script to set version**
- **Mobile: fix more signal handlers**
- **Mobile: on Desktop, automate finding modules and plugins**
- **Mobile: ImageDownloader can't be global**
- **Mobile: don't emit reset when clearing an empty list**
- **Mobile: make startup less verbose**
- **Android: allow building with podman or docker**
- **Mobile: use ninja for builds and appropriate parallelism**
- **build system: we now need ninja for the builds that check mobile**
- **Mobile: fix profile panning**
- **Mobile: wrap email shown in GlobalDrawer**
- **Mobile: ensure theme is fully initialized**
- **Mobile: prevent crash because of lazy initialization**
- **Mobile: prevent empty context menu**
- **Mobile: show full git version**
- **Cleanup: don't use nproc on Macs**
- **Mobile: fix invisible menu items**
- **Cleanup: update the copyright years**
- **Mobile: bundle translations with the app**
- **Android: switch to an adaptive icon**
- **iOS: declare that we use no nonstandard encryption**
- **Mobile: ensure that the DiveDetails snap to dives**
- **Mobile: reset the profile zoom when changing dive**
- **Mobile: prevent getting stuck in pan mode**
- **Mobile: ensure that contentX stays snapped when rotating**
- **Mobile: bring back breadcrumbs in title bar**
- **Mobile: only show breadcrumbs in single column mode**
- **Mobile: fix styling of chart selection on Statistics page**
- **Mobile: show chart icons**
- **Mobile: be less aggressive creating multi column layout**
- **Mobile: don't show back/forward buttons in title**
- **Mobile: improve dive edit on narrow screens**
- **Mobile: adjust settings page for narrow columns**
- **Android: build and bundle the Google maps plugin**
- **Mobile: try harder to get correct theme colors**
- **Android: persist googlemaps build outside of container**
- **Android: allow specifying different .secrets and appId**
- **Android: switch to Qt 6.10.2 for 16kB page support**
- **Cleanup: fix FolderDialog use**
- **Cleanup: fix DivePlannerEdit to prevent plan generation on enter**
- **Cleanup: consistent bottom padding**
- **Use Q_APPLICATION_STATIC for ImageDownloader and VideoFrameExtractor**
- **Cleanup: remove Qt 6.8 hack for Android**
- **Cleanup: remove pointless GitHub artifact**
- **Cleanup: remove unnecessary Component and deprecated variant type**
- **Cleanup: avoid race condition in animation**
- **Cleanup: fix several Android build script issues**
- **Cleanup: build fix for Qt 5**
- **Cleanup: don't build googlemaps under its src dir**
- **Cloud storage: don't reuse connection**
- **Cleanup: fixes in response to the PR review**
- **Add links to the Android artifact to pull requests.**
- **Android: change version numbering of container**
- **Android: use Qt 6.10.3 everywhere**
- **Android: increase docker version**
- **Android: avoid updating ssrf-version.h timestamp**
- **Android: improve local build script**
- **Android: update README to match scripts**
- **Improve get-dep-lib script**
- **Android: make the local build script avoid unnecessary rebuilds**
- **Android: avoid re-cloning and patching of Kirigami et al**
- **Android: only run cmake if there was no previous build**
- **Android: avoid rebuilding and installing libdc**
- **Android: use absolute path in GitHub Action**
- **Android: running the local build in rootful docker**
- **Update metainfo for Flathub**
- **Update libdivecomputer to the latest on 'Subsurface-DS9'.**
- **Include file based importers and dive computers not in libdivecomputer in the supported dive computer list.**
- **flathub: add icon that complies with Flathub rules**
- **update metainfo version to rolling release scheme**
- **CICD: Make it possible to get the version offline.**
- **Fix the command line parser.**
- **Replace the use of '.gitversion' with 'latest-subsurface-buildnumber'.**
- **Fixed typo in comment.**
- **Remove the OBS build setup as this has been discontinued.**
- **Bump softprops/action-gh-release from 2 to 3**
- **Bump insightsengineering/pip-action from 2.0.1 to 2.0.2**
- **Android: close app via back button**
- **Android: move state maintained on host into container**
- **Import: Support Suunto app exports (JSON parser, .json/.fit filters)**
- **tests: Skip Suunto JSON import tests on mobile**
- **Clean up the leftovers from the Qt5 Android builds.**
- **Android: only exit on back key from top level**
- **CICD: Update the 'latest release' in nightly-builds.**
- **copr: address issues in Fedora 44 build**
- **Fix #4775: Use secure.geonames.org for https requests**
- **Add comment pointing to the geonames API endpoints.**
- **copr: fix two editing errors**
- **Flatpak: make special icon Flathub specific**
- **mobile: avoid crash in DiveImportedModel on exit**
- **Android: avoid crash on unsatisfied Java dependency**
- **Android: avoid crash in DiveShare uploader**
- **Planner: avoid crash with drop stone mode in uninitialized plan**
- **Android: avoid crash during BLE download**
- **[BugFix] Fixed midnight datetime bug.**
- **Import: Extract Firmware Version / Serial Number for All Dive Computers.**
- **Import: Extract Firmware Version / Serial Number from File Imports.**
- **Update test data to match the importer changes.**
- **Android: Add Option to Build 'debug' APKs.**
- **Android: Refactor the Build Commands into the In-container Script.**
- **Move file not needed for the container build out of container directory.**
- **Have Pull Request Builds for Android Use '-debug'.**
- **cleanup: remove another NULL return for std::string**
- **translations: fix Qt 6 QtLinguist usage**
- **update translation source files**
- **Transifex: update config**
- **Transifex: updated translations**
- **add Ubuntu 26.04 Resolute Raccoon**
- **update translations**
- **translation updates BG/FR/NO/PT**
- **Bump negrutiu/nsis-install from 2 to 3**
- **Turning on the printing again**
- **Open a widget and show the log for printing**
- **Add actual printing**
- **Habemus profile**
- **restore old printing**
- **cleanup: remove support for WebEngine**
- **QLiteHtml: untangle creating the print content and the preview**
- **QLiteHtml: the previewWidget needs a layout**
- **QLiteHtml: add filter to print template loading**
- **QLiteHtml: don't break dives in Flow layout**
- **update QLiteHtml**
- **cleanup: remove CSS overrides not needed with latest litehtml**
- **cleanup: remove pointless whitespace in replacement text**
- **cleanup: make regex more flexible**
- **Windows/MSVC: don't hardcode QLiteHtml version**
- **Printing: restore the old default size**
- **disable TestPrinting**
- **Update libdivecomputer to latest on 'Subsurface-DS9'.**
- **cleanup: don't give pointless warning for flathub builds**
- **desktop: attempt to pick a reasonable default font size**
- **metainfo: slightly darken brand colors**
- **metainfo: update screenshots**
- **Update libdivecomputer to Latest in Upstream.**
- **Update Tests to Match the libdivecomputer Changes.**
- **Update libdivecomputer to latest on 'Subsurface-DS9'.**
- **Android: try harder not to crash**
- **update build and best practices badges in README**
- **Android: updates for gradle 10 and latest SDK**
- **cleanup: explicit permissions for GitHub Actions**
- **CICD: Update the Windows Runner.**
- **launchpad: try to fix the GitHub action uploading builds**
- **cleanup: fix inherited GitHub Action permissions**
- **CICD: Fix the Workflow Permissions.**
- **Import: Fix Serial Number / Firmware for Suunto JSON.**
- **launchpad: don't give up on first error**
- **CICD: Fix Input Interpolation Vulnerability.**
- **Update libdivecomputer to latest on 'Subsurface-DS9'.**
- **Fix Potential Use-after-free Error in Firmware Uploader**
- **CICD: Retry Launchpad dput Uploads on Transient Failures.**
- **Fix Build Warnings.**
- **Fix Warnings in Test Build.**
- **Fix building with printing.**
- **Fix Printing and Re-enable the Tests.**
- **Separate code paths for QtWebView / QLiteHtml for print previews.**
- **Add more generic support for legacy / Qt5 template printing in Qt6.**
- **fix(divelist): Prevent 'Collapse others' from collapsing all**
- **fix(plan): Show 'Sea water' on plan mode init to match defaults**
- **Android: Fix BLE Unreliability when Connecting.**
- **Bump actions/checkout from 6 to 7**
- **CICD: Comment "First appeared in release vX." on Pull Requests when Merged.**
- **CICD: Add a Script to Find Pull Requests Included in a Release.**

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a release helper script that lists pull request numbers included in a specified CICD release tag range.

* **Bug Fixes**
  * Improved dive log export reliability by tightening cleanup behavior, restoring the numeric locale consistently, and preventing resource leaks during JSON/XSLT export.

* **Changes**
  * Updated XSLT numeric calculations to remove rounding/`format-number` behavior for tank volume and interpolated depth outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->