### PR TITLE
Export: Streamline XML Based Exports

### DIFF
--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -3249,6 +3249,9 @@ A dive log or part of it can be saved in several formats:
 * _Subsurface dive sites XML_. Export the dive sites in XML format. This allows the
   sharing of dive sites with other divers or software.
 
+* _KML dive sites_. Export dive sites with GPS coordinates in KML format for use
+  with Google Earth and similar applications.
+
 * Universal Dive Data Format (_UDDF_). Refer to _https://uddf.org/_ for more information.
   UDDF is a generic format that enables communication among many dive computers
   and computer programs.

--- a/backend-shared/exportfuncs.cpp
+++ b/backend-shared/exportfuncs.cpp
@@ -24,6 +24,7 @@
 #include <QFileInfo>
 #include <QtConcurrent>
 #include <memory>
+#include <utility>
 
 // Default implementation of the export callback: do nothing / never cancel
 void ExportCallback::setProgress(int)
@@ -365,5 +366,13 @@ QFuture<std::pair<int, std::string>> exportUsingStyleSheet(const QString &filena
 	const QString &stylesheet, bool anonymize)
 {
 	return QtConcurrent::run(export_dives_xslt, filename.toUtf8(), doExport, units, stylesheet.toUtf8(), anonymize);
+}
+
+QFuture<std::pair<int, std::string>> exportDiveSitesUsingStyleSheet(const QString &filename,
+		std::vector<const dive_site *> sites, const QString &stylesheet, bool anonymize)
+{
+	return QtConcurrent::run([filename, sites = std::move(sites), stylesheet, anonymize]() {
+		return export_dive_sites_xslt(qPrintable(filename), sites, qPrintable(stylesheet), anonymize);
+	});
 }
 #endif

--- a/backend-shared/exportfuncs.h
+++ b/backend-shared/exportfuncs.h
@@ -4,6 +4,7 @@
 
 #include <QString>
 #include <QFuture>
+#include <vector>
 #include "profile-widget/profilescene.h"
 
 struct dive_site;
@@ -22,6 +23,8 @@ void export_TeX(const char *filename, bool selected_only, bool plain, ExportCall
 void export_depths(const char *filename, bool selected_only);
 std::vector<const dive_site *> getDiveSitesToExport(bool selectedOnly);
 QFuture<std::pair<int, std::string>> exportUsingStyleSheet(const QString &filename, bool doExport, int units, const QString &stylesheet, bool anonymize);
+QFuture<std::pair<int, std::string>> exportDiveSitesUsingStyleSheet(const QString &filename,
+		std::vector<const dive_site *> sites, const QString &stylesheet, bool anonymize);
 
 // prepareDivesForUploadDiveLog
 // prepareDivesForUploadDiveShare

--- a/core/dive.h
+++ b/core/dive.h
@@ -185,8 +185,8 @@ extern int save_dives(const char *filename);
 extern int save_dives_logic(const char *filename, bool select_only, bool anonymize);
 extern int save_dive(FILE *f, const struct dive &dive, bool anonymize);
 extern std::pair<int, std::string> export_dives_xslt(const char *filename, bool selected, const int units, const char *export_xslt, bool anonymize);
-
-extern int save_dive_sites_logic(const char *filename, const struct dive_site *sites[], int nr_sites, bool anonymize);
+extern std::pair<int, std::string> export_dive_sites_xslt(const char *filename, const std::vector<const dive_site *> &sites,
+		const char *export_xslt, bool anonymize);
 
 struct membuffer;
 extern void save_one_dive_to_mb(struct membuffer *b, const struct dive &dive, bool anonymize);

--- a/core/save-xml.cpp
+++ b/core/save-xml.cpp
@@ -822,9 +822,15 @@ static std::pair<int, std::string> transform_xslt(const char *filename, struct m
 	/* Write the transformed export to file */
 	f = subsurface_fopen(filename, "w");
 	if (f) {
-		xsltSaveResultToFile(f, transformed, xslt);
-		fclose(f);
-		/* Check write errors? */
+		int write_result = xsltSaveResultToFile(f, transformed, xslt);
+		int write_error = write_result < 0 ? errno : 0;
+		int close_result = fclose(f);
+		int close_error = close_result != 0 ? errno : 0;
+		if (write_result < 0 || close_result != 0) {
+			int error = close_error ? close_error : write_error;
+			res = std::make_pair(-1, format_string_std(translate("gettextFromC", "Failed to write %s (%s)"), filename,
+					strerror(error ? error : EIO)));
+		}
 	} else {
 		res = std::make_pair(-1, format_string_std(translate("gettextFromC", "Failed to open %s for writing (%s)"), filename, strerror(errno)));
 	}

--- a/core/save-xml.cpp
+++ b/core/save-xml.cpp
@@ -618,6 +618,25 @@ static void save_filter_presets(struct membuffer *b)
 	put_format(b, "</filterpresets>\n");
 }
 
+static void save_one_dive_site(struct membuffer *b, const struct dive_site &ds, bool anonymize)
+{
+	put_format(b, "<site uuid='%8x'", ds.uuid);
+	show_utf8_blanked(b, ds.name.c_str(), " name='", "'", 1, anonymize);
+	put_location(b, &ds.location, " gps='", "'");
+	show_utf8_blanked(b, ds.description.c_str(), " description='", "'", 1, anonymize);
+	put_format(b, ">\n");
+	show_utf8_blanked(b, ds.notes.c_str(), "  <notes>", " </notes>\n", 0, anonymize);
+	for (const auto &t: ds.taxonomy) {
+		if (t.category != TC_NONE && !t.value.empty()) {
+			put_format(b, "  <geo cat='%d'", t.category);
+			put_format(b, " origin='%d'", t.origin);
+			show_utf8_blanked(b, t.value.c_str(), " value='", "'", 1, anonymize);
+			put_format(b, "/>\n");
+		}
+	}
+	put_format(b, "</site>\n");
+}
+
 static void save_dives_buffer(struct membuffer *b, bool select_only, bool anonymize)
 {
 	put_format(b, "<divelog program='subsurface' version='%d'>\n<settings>\n", dataformat_version);
@@ -645,21 +664,7 @@ static void save_dives_buffer(struct membuffer *b, bool select_only, bool anonym
 		if (select_only && !ds->is_selected())
 			continue;
 
-		put_format(b, "<site uuid='%8x'", ds->uuid);
-		show_utf8_blanked(b, ds->name.c_str(), " name='", "'", 1, anonymize);
-		put_location(b, &ds->location, " gps='", "'");
-		show_utf8_blanked(b, ds->description.c_str(), " description='", "'", 1, anonymize);
-		put_format(b, ">\n");
-		show_utf8_blanked(b, ds->notes.c_str(), "  <notes>", " </notes>\n", 0, anonymize);
-		for (auto const &t: ds->taxonomy) {
-			if (t.category != TC_NONE && !t.value.empty()) {
-				put_format(b, "  <geo cat='%d'", t.category);
-				put_format(b, " origin='%d'", t.origin);
-				show_utf8_blanked(b, t.value.c_str(), " value='", "'", 1, anonymize);
-				put_format(b, "/>\n");
-			}
-		}
-		put_format(b, "</site>\n");
+		save_one_dive_site(b, *ds, anonymize);
 	}
 	put_format(b, "</divesites>\n<dives>\n");
 	for (auto &trip: divelog.trips)
@@ -776,23 +781,13 @@ int save_dives_logic(const char *filename, const bool select_only, bool anonymiz
 // This is executed in a separate thread with QtConcurrent::run
 // so we don't have access to NotificationWidget
 
-static std::pair<int, std::string> export_dives_xslt_doit(const char *filename, struct xml_params *params, bool selected, int units, const char *export_xslt, bool anonymize);
-
-std::pair<int, std::string> export_dives_xslt(const char *filename, const bool selected, const int units, const char *export_xslt, bool anonymize)
-{
-	struct xml_params *params = alloc_xml_params();
-	auto ret = export_dives_xslt_doit(filename, params, selected, units, export_xslt, anonymize);
-	free_xml_params(params);
-	return ret;
-}
-
-static std::pair<int, std::string> export_dives_xslt_doit(const char *filename, struct xml_params *params, bool selected, int units, const char *export_xslt, bool anonymize)
+static std::pair<int, std::string> transform_xslt(const char *filename, struct membuffer &buf,
+		struct xml_params *params, const char *export_xslt)
 {
 	FILE *f;
-	membuffer buf;
 	xmlDoc *doc;
 	xsltStylesheetPtr xslt = NULL;
-	xmlDoc *transformed;
+	xmlDoc *transformed = NULL;
 	auto res = std::make_pair(0, std::string());
 
 	if (verbose)
@@ -800,9 +795,6 @@ static std::pair<int, std::string> export_dives_xslt_doit(const char *filename, 
 
 	if (!filename)
 		return std::make_pair(-1, translate("gettextFromC", "No filename for export"));
-
-	/* Save XML to file and convert it into a memory buffer */
-	save_dives_buffer(&buf, selected, anonymize);
 
 	/*
 	 * Parse the memory buffer into XML document and
@@ -815,13 +807,17 @@ static std::pair<int, std::string> export_dives_xslt_doit(const char *filename, 
 
 	/* Convert to export format */
 	xslt = get_stylesheet(export_xslt);
-	if (!xslt)
+	if (!xslt) {
+		xmlFreeDoc(doc);
 		return std::make_pair(-1, translate("gettextFromC", "Failed to open export conversion stylesheet"));
-
-	xml_params_add_int(params, "units", units);
+	}
 
 	transformed = xsltApplyStylesheet(xslt, doc, xml_params_get(params));
 	xmlFreeDoc(doc);
+	if (!transformed) {
+		xsltFreeStylesheet(xslt);
+		return std::make_pair(-1, translate("gettextFromC", "Failed to transform XML for export"));
+	}
 
 	/* Write the transformed export to file */
 	f = subsurface_fopen(filename, "w");
@@ -838,55 +834,28 @@ static std::pair<int, std::string> export_dives_xslt_doit(const char *filename, 
 	return res;
 }
 
-static void save_dive_sites_buffer(struct membuffer *b, const struct dive_site *sites[], int nr_sites, bool anonymize)
-{
-	int i;
-	put_format(b, "<divesites program='subsurface' version='%d'>\n", dataformat_version);
-
-	/* save the dive sites */
-	for (i = 0; i < nr_sites; i++) {
-		const struct dive_site *ds = sites[i];
-
-		put_format(b, "<site uuid='%8x'", ds->uuid);
-		show_utf8_blanked(b, ds->name.c_str(), " name='", "'", 1, anonymize);
-		put_location(b, &ds->location, " gps='", "'");
-		show_utf8_blanked(b, ds->description.c_str(), " description='", "'", 1, anonymize);
-		put_format(b, ">\n");
-		show_utf8_blanked(b, ds->notes.c_str(), "  <notes>", " </notes>\n", 0, anonymize);
-		for (const auto &t: ds->taxonomy) {
-			if (t.category != TC_NONE && !t.value.empty()) {
-				put_format(b, "  <geo cat='%d'", t.category);
-				put_format(b, " origin='%d'", t.origin);
-				show_utf8_blanked(b, t.value.c_str(), " value='", "'", 1, anonymize);
-				put_format(b, "/>\n");
-			}
-		}
-		put_format(b, "</site>\n");
-	}
-	put_format(b, "</divesites>\n");
-}
-
-int save_dive_sites_logic(const char *filename, const struct dive_site *sites[], int nr_sites, bool anonymize)
+std::pair<int, std::string> export_dives_xslt(const char *filename, const bool selected, const int units,
+		const char *export_xslt, bool anonymize)
 {
 	membuffer buf;
-	FILE *f;
-	int error = 0;
+	xml_params params;
+	save_dives_buffer(&buf, selected, anonymize);
+	xml_params_add_int(&params, "units", units);
+	return transform_xslt(filename, buf, &params, export_xslt);
+}
 
-	save_dive_sites_buffer(&buf, sites, nr_sites, anonymize);
+std::pair<int, std::string> export_dive_sites_xslt(const char *filename,
+		const std::vector<const dive_site *> &sites, const char *export_xslt, bool anonymize)
+{
+	membuffer buf;
+	xml_params params;
 
-	if (same_string(filename, "-")) {
-		f = stdout;
-	} else {
-		try_to_backup(filename);
-		error = -1;
-		f = subsurface_fopen(filename, "w");
+	// Build a sites-only SSRF document using the same serializer as the native log format.
+	put_format(&buf, "<divelog program='subsurface' version='%d'>\n<divesites>\n", dataformat_version);
+	for (const dive_site *site: sites) {
+		if (site && !site->is_empty())
+			save_one_dive_site(&buf, *site, anonymize);
 	}
-	if (f) {
-		flush_buffer(&buf, f);
-		error = fclose(f);
-	}
-	if (error)
-		report_error(translate("gettextFromC", "Failed to save divesites to %s (%s)"), filename, strerror(errno));
-
-	return error;
+	put_format(&buf, "</divesites>\n</divelog>\n");
+	return transform_xslt(filename, buf, &params, export_xslt);
 }

--- a/desktop-widgets/divelogexportdialog.cpp
+++ b/desktop-widgets/divelogexportdialog.cpp
@@ -99,6 +99,8 @@ void DiveLogExportDialog::showExplanation()
 		ui->description->setText(tr("Subsurface native XML format."));
 	} else if (ui->exportSubsurfaceSitesXML->isChecked()) {
 		ui->description->setText(tr("Subsurface dive sites native XML format."));
+	} else if (ui->exportKML->isChecked()) {
+		ui->description->setText(tr("Dive sites in KML format for Google Earth and similar applications."));
 	} else if (ui->exportImageDepths->isChecked()) {
 		ui->description->setText(tr("Write depths of images to file."));
 	} else if (ui->exportTeX->isChecked()) {
@@ -163,6 +165,7 @@ void DiveLogExportDialog::on_buttonBox_accepted()
 {
 	QString filename;
 	QString stylesheet;
+	bool sitesOnly = false;
 	QString lastDir = QDir::homePath();
 
 	if (QDir(qPrefDisplay::lastDir()).exists())
@@ -201,15 +204,19 @@ void DiveLogExportDialog::on_buttonBox_accepted()
 				save_dives_logic(bt.data(), ui->exportSelected->isChecked(), ui->anonymize->isChecked());
 			}
 		} else if (ui->exportSubsurfaceSitesXML->isChecked()) {
+			stylesheet = "divesites-export.xslt";
+			sitesOnly = true;
 			filename = QFileDialog::getSaveFileName(this, tr("Export Subsurface dive sites XML"), lastDir,
 								tr("Subsurface files") + " (*.xml)");
-			if (!filename.isEmpty()) {
-				if (!filename.contains('.'))
-					filename.append(".xml");
-				QByteArray bt = QFile::encodeName(filename);
-				auto sites = getDiveSitesToExport(ui->exportSelected->isChecked());
-				save_dive_sites_logic(bt.data(), sites.data(), (int)sites.size(), ui->anonymize->isChecked());
-			}
+			if (!filename.isEmpty() && !filename.contains('.'))
+				filename.append(".xml");
+		} else if (ui->exportKML->isChecked()) {
+			stylesheet = "kml-export.xslt";
+			sitesOnly = true;
+			filename = QFileDialog::getSaveFileName(this, tr("Export dive sites as KML"), lastDir,
+								tr("KML files") + " (*.kml)");
+			if (!filename.isEmpty() && !filename.contains('.'))
+				filename.append(".kml");
 		} else if (ui->exportImageDepths->isChecked()) {
 			filename = QFileDialog::getSaveFileName(this, tr("Save image depths"), lastDir);
 			if (!filename.isEmpty())
@@ -246,8 +253,11 @@ void DiveLogExportDialog::on_buttonBox_accepted()
 		qPrefDisplay::set_lastDir(fileInfo.dir().path());
 		// the non XSLT exports are called directly above, the XSLT based ons are called here
 		if (!stylesheet.isEmpty()) {
-			QFuture<std::pair<int, std::string>> future = exportUsingStyleSheet(filename, ui->exportSelected->isChecked(),
-					ui->CsvUnits_2->currentIndex(), stylesheet.toUtf8(), ui->anonymize->isChecked());
+			QFuture<std::pair<int, std::string>> future = sitesOnly ?
+				exportDiveSitesUsingStyleSheet(filename, getDiveSitesToExport(ui->exportSelected->isChecked()),
+						stylesheet, ui->anonymize->isChecked()) :
+				exportUsingStyleSheet(filename, ui->exportSelected->isChecked(), ui->CsvUnits_2->currentIndex(),
+						stylesheet, ui->anonymize->isChecked());
 			MainWindow::instance()->getNotificationWidget()->showNotification(tr("Please wait, exporting..."), KMessageWidget::Information);
 			MainWindow::instance()->getNotificationWidget()->setFuture(future);
 		}

--- a/desktop-widgets/divelogexportdialog.ui
+++ b/desktop-widgets/divelogexportdialog.ui
@@ -320,6 +320,16 @@
            </widget>
           </item>
           <item>
+           <widget class="QRadioButton" name="exportKML">
+            <property name="text">
+             <string>KML dive sites</string>
+            </property>
+            <attribute name="buttonGroup">
+             <string notr="true">exportGroup</string>
+            </attribute>
+           </widget>
+          </item>
+          <item>
            <widget class="QRadioButton" name="exportUDDF">
             <property name="maximumSize">
              <size>
@@ -786,6 +796,22 @@
   </connection>
   <connection>
    <sender>exportSubsurfaceSitesXML</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>anonymize</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>39</x>
+     <y>168</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>322</x>
+     <y>171</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>exportKML</sender>
    <signal>toggled(bool)</signal>
    <receiver>anonymize</receiver>
    <slot>setEnabled(bool)</slot>

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -2225,7 +2225,9 @@ void QMLManager::exportToFile(export_types type, QString dir, bool anonymize)
 		case EX_DIVE_SITES_XML:
 			{
 				auto sites = getDiveSitesToExport(false);
-				export_dive_sites_xslt(qPrintable(fileName + ".xml"), sites, "divesites-export.xslt", anonymize);
+				auto result = export_dive_sites_xslt(qPrintable(fileName + ".xml"), sites, "divesites-export.xslt", anonymize);
+				if (result.first)
+					report_error("%s", result.second.c_str());
 				break;
 			}
 		default:

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -2225,7 +2225,7 @@ void QMLManager::exportToFile(export_types type, QString dir, bool anonymize)
 		case EX_DIVE_SITES_XML:
 			{
 				auto sites = getDiveSitesToExport(false);
-				save_dive_sites_logic(qPrintable(fileName + ".xml"), sites.data(), (int)sites.size(), anonymize);
+				export_dive_sites_xslt(qPrintable(fileName + ".xml"), sites, "divesites-export.xslt", anonymize);
 				break;
 			}
 		default:
@@ -2273,7 +2273,7 @@ void QMLManager::shareViaEmail(export_types type, bool anonymize)
 		fileName.replace("subsurface.log", "subsurface_divesites.xml");
 		{ // need a block so the compiler doesn't complain about creating the sites variable here
 			auto sites = getDiveSitesToExport(false);
-			if (save_dive_sites_logic(qPrintable(fileName), sites.data(), (int)sites.size(), anonymize) == 0) {
+			if (export_dive_sites_xslt(qPrintable(fileName), sites, "divesites-export.xslt", anonymize).first == 0) {
 				// ok, we have a file, let's send it
 				body = "Subsurface dive site data";
 			} else {

--- a/subsurface.qrc
+++ b/subsurface.qrc
@@ -28,10 +28,12 @@
         <file>xslt/commonTemplates.xsl</file>
         <file>xslt/csv2xml.xslt</file>
         <file>xslt/divelogs-export.xslt</file>
+        <file>xslt/divesites-export.xslt</file>
         <file>xslt/divelogs.xslt</file>
         <file>xslt/DivingLog.xslt</file>
         <file>xslt/Mares.xslt</file>
         <file>xslt/jdivelog2subsurface.xslt</file>
+        <file>xslt/kml-export.xslt</file>
         <file>xslt/MacDive.xslt</file>
         <file>xslt/SuuntoDM4.xslt</file>
         <file>xslt/SuuntoSDM.xslt</file>

--- a/tests/testparse.cpp
+++ b/tests/testparse.cpp
@@ -530,6 +530,12 @@ void TestParse::exportKML()
 	QCOMPARE(name, QStringLiteral("Lake & Ice"));
 	QCOMPARE(description, QStringLiteral("Alpine <lake>\nBring a drysuit"));
 	QCOMPARE(coordinates, QStringLiteral("171.545936,-43.342295,0"));
+
+#if defined(Q_OS_LINUX)
+	result = export_dive_sites_xslt("/dev/full", allDiveSites(), "kml-export.xslt", false);
+	QVERIFY(result.first != 0);
+	QVERIFY(!result.second.empty());
+#endif
 }
 
 void TestParse::importUDDF()

--- a/tests/testparse.cpp
+++ b/tests/testparse.cpp
@@ -13,6 +13,7 @@
 #include "core/trip.h"
 #include "core/xmlparams.h"
 #include <QTextStream>
+#include <QXmlStreamReader>
 
 /* We have to use a macro since QCOMPARE
  * can only be called from a test method
@@ -450,6 +451,85 @@ void TestParse::exportUDDF()
 
 	export_dives_xslt("testuddfexport.uddf", 0, 1, "uddf-export.xslt", false);
 	FILE_COMPARE("testuddfexport.uddf", SUBSURFACE_TEST_DATA "/dives/test42.uddf");
+}
+
+static std::vector<const dive_site *> allDiveSites()
+{
+	std::vector<const dive_site *> sites;
+	sites.reserve(divelog.sites.size());
+	for (const auto &site: divelog.sites)
+		sites.push_back(site.get());
+	return sites;
+}
+
+void TestParse::exportDiveSitesXML()
+{
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test42.xml", &divelog), 0);
+	dive_site *site = divelog.sites.get_by_uuid(0xec2bbc32);
+	QVERIFY(site);
+	site->name = "Lake & Ice";
+	site->description = "Alpine <lake>";
+	site->notes = "Bring a drysuit";
+	taxonomy_set_category(site->taxonomy, TC_COUNTRY, "New Zealand", GEOMANUAL);
+
+	auto result = export_dive_sites_xslt("testdivesites.xml", allDiveSites(), "divesites-export.xslt", false);
+	QCOMPARE(result.first, 0);
+	QVERIFY2(result.second.empty(), result.second.c_str());
+
+	clear_dive_file_data();
+	QCOMPARE(parse_file("testdivesites.xml", &divelog), 0);
+	site = divelog.sites.get_by_uuid(0xec2bbc32);
+	QVERIFY(site);
+	QCOMPARE(site->name, std::string("Lake & Ice"));
+	QCOMPARE(site->description, std::string("Alpine <lake>"));
+	QCOMPARE(site->notes, std::string("Bring a drysuit"));
+	QCOMPARE(site->location.lat.udeg, -43342295);
+	QCOMPARE(site->location.lon.udeg, 171545936);
+	QCOMPARE(taxonomy_get_value(site->taxonomy, TC_COUNTRY), std::string("New Zealand"));
+}
+
+void TestParse::exportKML()
+{
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test42.xml", &divelog), 0);
+	dive_site *site = divelog.sites.get_by_uuid(0xec2bbc32);
+	QVERIFY(site);
+	site->name = "Lake & Ice";
+	site->description = "Alpine <lake>";
+	site->notes = "Bring a drysuit";
+	divelog.sites.create("Site without coordinates");
+
+	auto result = export_dive_sites_xslt("testdivesites.kml", allDiveSites(), "kml-export.xslt", false);
+	QCOMPARE(result.first, 0);
+	QVERIFY2(result.second.empty(), result.second.c_str());
+
+	QFile file("testdivesites.kml");
+	QVERIFY(file.open(QIODevice::ReadOnly));
+	QXmlStreamReader xml(&file);
+	int placemarks = 0;
+	QString name;
+	QString description;
+	QString coordinates;
+	while (!xml.atEnd()) {
+		xml.readNext();
+		if (!xml.isStartElement())
+			continue;
+		if (xml.name() == QStringLiteral("kml"))
+			QCOMPARE(xml.namespaceUri().toString(), QStringLiteral("http://www.opengis.net/kml/2.2"));
+		else if (xml.name() == QStringLiteral("Placemark"))
+			placemarks++;
+		else if (xml.name() == QStringLiteral("name") && placemarks > 0)
+			name = xml.readElementText();
+		else if (xml.name() == QStringLiteral("description"))
+			description = xml.readElementText();
+		else if (xml.name() == QStringLiteral("coordinates"))
+			coordinates = xml.readElementText().trimmed();
+	}
+
+	QVERIFY2(!xml.hasError(), qPrintable(xml.errorString()));
+	QCOMPARE(placemarks, 1);
+	QCOMPARE(name, QStringLiteral("Lake & Ice"));
+	QCOMPARE(description, QStringLiteral("Alpine <lake>\nBring a drysuit"));
+	QCOMPARE(coordinates, QStringLiteral("171.545936,-43.342295,0"));
 }
 
 void TestParse::importUDDF()

--- a/tests/testparse.h
+++ b/tests/testparse.h
@@ -36,6 +36,8 @@ private slots:
 	int parseCSVprofile(int, std::string);
 	void exportCSVDiveProfile();
 	void exportUDDF();
+	void exportDiveSitesXML();
+	void exportKML();
 	void importUDDF();
 	void exportDiveLogsDE();
 

--- a/xslt/divesites-export.xslt
+++ b/xslt/divesites-export.xslt
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="xml" encoding="UTF-8" indent="yes" omit-xml-declaration="yes"/>
+  <xsl:strip-space elements="*"/>
+
+  <xsl:template match="/divelog">
+    <divesites>
+      <xsl:attribute name="program"><xsl:value-of select="@program"/></xsl:attribute>
+      <xsl:attribute name="version"><xsl:value-of select="@version"/></xsl:attribute>
+      <xsl:copy-of select="divesites/site"/>
+    </divesites>
+  </xsl:template>
+</xsl:stylesheet>

--- a/xslt/kml-export.xslt
+++ b/xslt/kml-export.xslt
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="xml" encoding="UTF-8" indent="yes"/>
+  <xsl:strip-space elements="*"/>
+
+  <xsl:template match="/">
+    <kml xmlns="http://www.opengis.net/kml/2.2">
+      <Document>
+        <name>Subsurface dive sites</name>
+        <xsl:apply-templates select="divelog/divesites/site[string-length(normalize-space(@gps)) &gt; 0]"/>
+      </Document>
+    </kml>
+  </xsl:template>
+
+  <xsl:template match="site">
+    <!-- The SSRF serializer places one formatting space before </notes>. -->
+    <xsl:variable name="notes" select="substring(notes, 1, string-length(notes) - 1)"/>
+    <Placemark xmlns="http://www.opengis.net/kml/2.2">
+      <name><xsl:value-of select="@name"/></name>
+      <xsl:if test="@description != '' or $notes != ''">
+        <description>
+          <xsl:value-of select="@description"/>
+          <xsl:if test="@description != '' and $notes != ''"><xsl:text>&#10;</xsl:text></xsl:if>
+          <xsl:value-of select="$notes"/>
+        </description>
+      </xsl:if>
+      <Point>
+        <coordinates>
+          <xsl:value-of select="substring-after(normalize-space(@gps), ' ')"/>
+          <xsl:text>,</xsl:text>
+          <xsl:value-of select="substring-before(normalize-space(@gps), ' ')"/>
+          <xsl:text>,0</xsl:text>
+        </coordinates>
+      </Point>
+    </Placemark>
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
Convert the 'Subsurface Dive Sites' export to using a canonical 'SSRF'
export and then convert to dive sites.
Add KML export.

Alternative to #4630.

Signed-off-by: Michael Keller <github@ike.ch>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added KML export for dive sites with GPS coordinates (for Google Earth and similar apps).
  * Added an XSLT-based dive-site XML export option, including format descriptions and filename handling.
* **Bug Fixes**
  * Improved export error handling when stylesheets are missing, invalid, or transformation fails.
* **Tests**
  * Added/extended automated checks for dive-site XML and KML exports, including KML structure, content, coordinates, and failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->